### PR TITLE
Remove the warning of requiresMainQueueSetup

### DIFF
--- a/ios/AndroidNavbarHeight.m
+++ b/ios/AndroidNavbarHeight.m
@@ -4,6 +4,8 @@
 
 RCT_EXTERN_METHOD(multiply:(float)a withB:(float)b
                  withResolver:(RCTPromiseResolveBlock)resolve
-                 withRejecter:(RCTPromiseRejectBlock)reject)
+                 withRejecter:(RCTPromiseRejectBlock)reject);
+
++(BOOL)requiresMainQueueSetup   {   return NO;   };
 
 @end


### PR DESCRIPTION
>  Module AndroidNavbarHeight requires main queue setup since it overrides `init` but doesn't implement `requiresMainQueueSetup`. In a future release React Native will default to initializing all native modules on a background thread unless explicitly opted-out of.

Above warning was removed.